### PR TITLE
Fix QTimer usage and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ The `main()` function defined in [`reep.py`](./reep.py) performs dependency chec
 ## Notes
 - Always test with the Binance testnet before trading live funds.
 - This project is for educational purposes and does not constitute financial advice.
+
+## License
+This project is licensed under the [MIT License](LICENSE).
+

--- a/reep.py
+++ b/reep.py
@@ -23,7 +23,7 @@ from PyQt5.QtWidgets import (
     QTextEdit, QTabWidget, QMessageBox, QFileDialog,
     QProgressBar, QCheckBox
 )
-from PyQt5.QtCore import Qt, QThread, pyqtSignal
+from PyQt5.QtCore import Qt, QThread, pyqtSignal, QTimer
 from PyQt5.QtGui import QFont, QColor
 
 class EnhancedBinanceAPI:


### PR DESCRIPTION
## Summary
- fix `NameError` by importing `QTimer`
- add MIT license
- mention license in README

## Testing
- `python -m py_compile reep.py`

------
https://chatgpt.com/codex/tasks/task_b_683d373bb8bc83308035a339bac6b7dc