### PR TITLE
Add chart and trading actions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This project provides an advanced, GUI-based trading bot for Binance that levera
 - Professional dark-themed UI with live updates
 - Export of signal history and model persistence
 - Built-in testnet support for safe development and testing
+- Live price chart and optional auto-trading mode
+- Manual trade entry directly from the UI
 
 These features are summarized in the entry point docstring of [`reep.py`](./reep.py) around the `if __name__ == "__main__":` block.
 
@@ -29,6 +31,12 @@ python reep.py
 ```
 The `main()` function defined in [`reep.py`](./reep.py) performs dependency checks and launches the PyQt interface. Configure your Binance API credentials in the UI (use the Binance **testnet** initially) and select your preferred ML model to start trading.
 
+For manual trades, enter a quantity and optional limit price in the **Manual Trade** section, then click **Submit**. Enable **Auto Trade** to allow the bot to automatically place orders whenever a new ML signal is generated.
+
 ## Notes
 - Always test with the Binance testnet before trading live funds.
 - This project is for educational purposes and does not constitute financial advice.
+
+## License
+This project is licensed under the [MIT License](LICENSE).
+


### PR DESCRIPTION
## Summary
- draw a simple price chart in the trading tab
- allow manual trades and optional automatic trading
- place orders through Binance API
- document new chart and trading capabilities

## Testing
- `python -m py_compile reep.py`


------
https://chatgpt.com/codex/tasks/task_b_683d373bb8bc83308035a339bac6b7dc