### PR TITLE
Add candlestick chart, auto trading, and council model

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ This project provides an advanced, GUI-based trading bot for Binance that levera
 - Over 25 technical indicators from the `ta` library
 - Professional dark-themed UI with live updates
 - Real-time price chart widget visualizing recent prices
+- Candlestick chart for OHLC visualization
 - Export of signal history and model persistence
+- Manual trading interface for quick order execution
+- Optional auto-trading with quantity controls
+- Council model combining multiple algorithms
+- Built-in "Copy Source" button for easy code sharing
 - Optional advanced risk management and regime detection modules
 - Experimental online learning optimizer for real-time adaptation
 - Built-in testnet support for safe development and testing


### PR DESCRIPTION
## Summary
- display candlestick chart in the trading view
- optional auto-trading that submits orders from ML signals
- new "Council" ML mode using multiple models
- allow enabling auto-trade quantity in UI
- document features in README

## Testing
- `python -m py_compile reep.py`


------
https://chatgpt.com/codex/tasks/task_b_683d9f7df9548330bfea6a069863b41c