### PR TITLE
Implement simple auto trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project provides an advanced, GUI-based trading bot for Binance that levera
 - Candlestick chart for OHLC visualization
 - Export of signal history and model persistence
 - Manual trading interface for quick order execution
+- Optional auto trading mode to automatically execute ML signals
 - Built-in "Copy Source" button for easy code sharing
 - Detailed authentication error messages for easier API troubleshooting
 - Optional advanced risk management and regime detection modules

--- a/trading_ui.py
+++ b/trading_ui.py
@@ -261,6 +261,18 @@ class BinanceTradingApp(QMainWindow):
 
         layout.addWidget(manual_group)
 
+        # Auto trading controls
+        auto_group = QGroupBox("🤖 Auto Trading")
+        auto_layout = QHBoxLayout()
+        self.auto_trade_checkbox = QCheckBox("Enable Auto Trade")
+        self.auto_trade_qty = QLineEdit()
+        self.auto_trade_qty.setPlaceholderText("Qty per trade")
+        auto_layout.addWidget(self.auto_trade_checkbox)
+        auto_layout.addWidget(self.auto_trade_qty)
+        auto_group.setLayout(auto_layout)
+
+        layout.addWidget(auto_group)
+
         # Enhanced data tables
         self.setup_enhanced_tables(layout)
         
@@ -1218,6 +1230,22 @@ class BinanceTradingApp(QMainWindow):
             
             # Update analytics
             self.update_signal_analytics(signal_data)
+
+            # Auto trading if enabled
+            if (self.auto_trade_checkbox.isChecked() and signal_text in ("BUY", "SELL")):
+                qty_text = self.auto_trade_qty.text().strip()
+                try:
+                    qty = float(qty_text)
+                    if qty > 0:
+                        result = self.binance_api.place_order(
+                            self.current_symbol, signal_text, qty, "MARKET"
+                        )
+                        if "error" in result:
+                            self.update_connection_status(f"Auto trade error: {result['error']}")
+                        else:
+                            self.update_connection_status("✅ Auto trade executed")
+                except ValueError:
+                    self.update_connection_status("Invalid auto trade qty")
             
             # Maintain table sizes
             for table in [self.signals_table, self.ml_signals_table]:


### PR DESCRIPTION
## Summary
- add optional auto trading mode in the UI
- automatically execute orders when a ML signal is produced
- document auto trading in README

## Testing
- `python -m py_compile trading_ui.py trading_logic.py reep.py`
- `python reep.py` *(fails: name 'sys' is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_6842cf539de88330bf159b3ee6319e75