### PR TITLE
Add confidence threshold to auto trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This project provides an advanced, GUI-based trading bot for Binance that levera
 - Candlestick chart for OHLC visualization
 - Export of signal history and model persistence
 - Manual trading interface for quick order execution
+ - Optional auto trading mode to automatically execute ML signals
+ - Configurable confidence threshold for safer auto trading
 - Built-in "Copy Source" button for easy code sharing
 - Detailed authentication error messages for easier API troubleshooting
 - Optional advanced risk management and regime detection modules


### PR DESCRIPTION
## Summary
- add configurable confidence threshold for auto trades
- enforce threshold in auto trading logic

## Testing
- `python -m py_compile trading_ui.py trading_logic.py reep.py`
- `python reep.py` *(fails: Qt platform plugin "xcb" could not be initialized)*


------
https://chatgpt.com/codex/tasks/task_b_6842cf539de88330bf159b3ee6319e75